### PR TITLE
Overlap issue fix

### DIFF
--- a/Themes/default/css/portal.css
+++ b/Themes/default/css/portal.css
@@ -222,6 +222,13 @@ td.sp_shop
 {
 	margin: 5px 10px 0 0;
 }
+
+/* Overlap fix */
+.sp_article_content .post {
+	margin-right: -50px;
+	word-wrap: break-word;
+}
+
 .sp_article_content
 {
 	margin-bottom: 0.5em;


### PR DESCRIPTION
Stops the overlapping of the middle block and right block on the Simple Portal page.

Example:
https://www.moparscape.org/smf/index.php/topic,662102.msg4425684.html#msg4425684

Mainly a fix for the users with smaller screens

- Tiny_